### PR TITLE
Potential fix for code scanning alert no. 23: Information exposure through an exception

### DIFF
--- a/enocean/enocean_monitoring/enocean_gateway/web/dlq_routes.py
+++ b/enocean/enocean_monitoring/enocean_gateway/web/dlq_routes.py
@@ -1,6 +1,7 @@
 # web/dlq_routes.py
 from flask import Blueprint, jsonify, request
 from typing import Dict, Any
+import logging
 
 def create_dlq_routes(gateway_system) -> Blueprint:
     """Create Flask routes for Dead Letter Queue management"""
@@ -48,9 +49,10 @@ def create_dlq_routes(gateway_system) -> Blueprint:
                 "data": messages
             })
         except Exception as e:
+            logging.exception("Error in get_handler_dlq_messages for handler '%s':", handler_name)
             return jsonify({
                 "success": False,
-                "error": str(e)
+                "error": "An internal error has occurred."
             }), 500
     
     @dlq_bp.route('/health', methods=['GET'])


### PR DESCRIPTION
Potential fix for [https://github.com/cemakpolat/iot-simulated-devices/security/code-scanning/23](https://github.com/cemakpolat/iot-simulated-devices/security/code-scanning/23)

To fix the issue, exception messages (`str(e)`) should not be returned directly in API responses. Instead, respond with a generic error message (e.g., "An internal error has occurred.") so that no sensitive internal details are exposed. If exception details are needed for debugging, they should be logged server-side using Python's logging framework or similar, but never sent in responses.  

Specifically, in file `enocean/enocean_monitoring/enocean_gateway/web/dlq_routes.py`, update the exception handler in the `get_handler_dlq_messages` function (lines 50–54) to:  
- Replace `str(e)` in the response with a fixed, non-descriptive error message.
- Optionally, log the exception locally with stack trace (using `logging`).
Also, ensure you import the standard `logging` module for server-side error logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
